### PR TITLE
feat: 약관 모달 URL 파라미터 접근 지원

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium webkit --with-deps
+        run: pnpm exec playwright install chromium webkit
+
+      - name: Install Playwright system dependencies
+        run: pnpm exec playwright install-deps chromium webkit
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: validate-i18n
+    timeout-minutes: 60
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
 
@@ -45,20 +49,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium webkit
-
-      - name: Install Playwright system dependencies
-        run: pnpm exec playwright install-deps chromium webkit
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium webkit --with-deps
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import styles from "./Footer.module.css";
 import Image from "next/image";
 import { logoIcon } from "@/assets/icons";
@@ -13,10 +13,53 @@ import { privacyEn } from "@/content/privacy/en";
 
 type ModalType = "terms" | "privacy" | null;
 
+function getLegalModalType(value: string | null): ModalType {
+  if (value === "terms" || value === "privacy") return value;
+  return null;
+}
+
 export default function Footer() {
   const t = useTranslations("Footer");
   const locale = useLocale();
   const [openModal, setOpenModal] = useState<ModalType>(null);
+
+  const getModalTypeFromUrl = useCallback(() => {
+    return getLegalModalType(
+      new URLSearchParams(window.location.search).get("legal")
+    );
+  }, []);
+
+  const updateLegalParam = useCallback(
+    (modalType: ModalType, mode: "push" | "replace" = "push") => {
+      const url = new URL(window.location.href);
+
+      if (modalType) {
+        url.searchParams.set("legal", modalType);
+      } else {
+        url.searchParams.delete("legal");
+      }
+
+      const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+      window.history[mode === "push" ? "pushState" : "replaceState"](
+        window.history.state,
+        "",
+        nextUrl
+      );
+      setOpenModal(modalType);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const syncModalWithUrl = () => {
+      setOpenModal(getModalTypeFromUrl());
+    };
+
+    syncModalWithUrl();
+    window.addEventListener("popstate", syncModalWithUrl);
+
+    return () => window.removeEventListener("popstate", syncModalWithUrl);
+  }, [getModalTypeFromUrl]);
 
   const terms = locale === "ko" ? termsKo : termsEn;
   const privacy = locale === "ko" ? privacyKo : privacyEn;
@@ -49,7 +92,7 @@ export default function Footer() {
             <button
               className={styles.legalLink}
               aria-haspopup="dialog"
-              onClick={() => setOpenModal("terms")}
+              onClick={() => updateLegalParam("terms")}
             >
               {t("terms")}
             </button>
@@ -57,7 +100,7 @@ export default function Footer() {
             <button
               className={styles.legalLink}
               aria-haspopup="dialog"
-              onClick={() => setOpenModal("privacy")}
+              onClick={() => updateLegalParam("privacy")}
             >
               {t("privacy")}
             </button>
@@ -73,7 +116,7 @@ export default function Footer() {
           title={activeContent.title}
           lastUpdated={activeContent.lastUpdated}
           body={activeContent.body}
-          onClose={() => setOpenModal(null)}
+          onClose={() => updateLegalParam(null, "replace")}
         />
       )}
     </footer>

--- a/tests/e2e/modals.spec.ts
+++ b/tests/e2e/modals.spec.ts
@@ -10,9 +10,29 @@ test.describe("Legal Modals", () => {
     await expect(page.getByRole("dialog", { name: /이용약관/ })).toBeVisible();
   });
 
+  test("이용약관 버튼 클릭 시 legal 파라미터 반영", async ({ page }) => {
+    await page.getByRole("button", { name: /이용약관/i }).click();
+    await expect(page).toHaveURL(/\/ko\?legal=terms$/);
+  });
+
   test("개인정보처리방침 버튼 클릭 시 모달 열림", async ({ page }) => {
     await page.getByRole("button", { name: /개인정보/i }).click();
     await expect(page.getByRole("dialog", { name: /개인정보/ })).toBeVisible();
+  });
+
+  test("개인정보취급방침 URL 접속 시 모달 자동 열림", async ({ page }) => {
+    await page.goto("/ko?legal=privacy");
+    await expect(page.getByRole("dialog", { name: /개인정보/ })).toBeVisible();
+  });
+
+  test("이용약관 URL 접속 시 모달 자동 열림", async ({ page }) => {
+    await page.goto("/ko?legal=terms");
+    await expect(page.getByRole("dialog", { name: /이용약관/ })).toBeVisible();
+  });
+
+  test("잘못된 legal 파라미터는 모달을 열지 않음", async ({ page }) => {
+    await page.goto("/ko?legal=unknown");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
   test("모달 열릴 때 배경 스크롤 잠금", async ({ page }) => {
@@ -32,6 +52,12 @@ test.describe("Legal Modals", () => {
 
     await page.getByRole("button", { name: /닫기/i }).click();
     await expect(modal).not.toBeVisible();
+  });
+
+  test("닫기 버튼 클릭 시 legal 파라미터 제거", async ({ page }) => {
+    await page.goto("/ko?legal=terms");
+    await page.getByRole("button", { name: /닫기/i }).click();
+    await expect(page).toHaveURL(/\/ko$/);
   });
 
   test("모달 닫힌 후 배경 스크롤 복원", async ({ page }) => {
@@ -62,5 +88,15 @@ test.describe("Legal Modals - English", () => {
     const modal = page.getByRole("dialog", { name: /terms/i });
     await expect(modal).toBeVisible();
     await expect(modal).toContainText("Terms");
+  });
+
+  test("Privacy Policy URL 접속 시 모달 자동 열림", async ({ page }) => {
+    await page.goto("/en?legal=privacy");
+    await expect(page.getByRole("dialog", { name: /privacy/i })).toBeVisible();
+  });
+
+  test("Terms of Service URL 접속 시 모달 자동 열림", async ({ page }) => {
+    await page.goto("/en?legal=terms");
+    await expect(page.getByRole("dialog", { name: /terms/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- `legal` query parameter로 개인정보취급방침/이용약관 모달을 직접 열 수 있도록 추가했습니다.
- Footer의 약관 링크 클릭 시 URL에 `legal` 파라미터가 반영되도록 변경했습니다.
- 모달 닫기 시 URL에서 `legal` 파라미터가 제거되도록 처리했습니다.
- 관련 E2E 테스트를 추가했습니다.

## Supported URLs

- 개인정보취급방침: https://talkhangyul.com/ko?legal=privacy
- 이용약관: https://talkhangyul.com/ko?legal=terms
- Privacy Policy: https://talkhangyul.com/en?legal=privacy
- Terms of Service: https://talkhangyul.com/en?legal=terms

## Test

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint src/components/layout/Footer.tsx tests/e2e/modals.spec.ts`
- [x] `pnpm test:e2e tests/e2e/modals.spec.ts`
- [x] `pnpm build`

## Note

- 전체 `pnpm lint`는 기존 `playwright-report` 산출물이 lint 대상에 포함되어 실패합니다.
- 이번 변경 파일 대상 lint는 통과했습니다.

## Related Issue

Closes #20 